### PR TITLE
Allow upload streams

### DIFF
--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -198,7 +198,7 @@ module FakeFtp
       respond_with('125 Do it!')
       data_client = active? ? @active_connection : @data_server.accept
 
-      data = data_client.recv(1024)
+      data = data_client.read(1024)
       file = FakeFtp::File.new(::File.basename(filename.to_s), data, @mode)
       @files << file
 

--- a/spec/models/fake_ftp/server_spec.rb
+++ b/spec/models/fake_ftp/server_spec.rb
@@ -278,6 +278,18 @@ describe FakeFtp::Server, 'commands' do
         # server.file('some_file').bytes.should == 10
       end
 
+      it "accepts STOR with streams" do
+        client.puts "STOR some_file"
+        client.gets.should == "125 Do it!\r\n"
+        data_client.write "1234567890"
+        data_client.flush
+        data_client.write "1234567890"
+        data_client.flush
+        data_client.close
+        client.gets.should == "226 Did it!\r\n"
+        server.file('some_file').data.should == "12345678901234567890"
+      end
+
       it "does not accept RETR without a filename" do
         client.puts "RETR"
         client.gets.should == "501 No filename given\r\n"


### PR DESCRIPTION
Hi

I use fake_ftp to test my ftp uploader. Thanks for this gem!

I've encountered bug which led to my tests failing randomly. I'm generating data on fly and using `Net::FTP#storlines` to immediately send that data to ftp server.

I found out that `TCPSocket#recv` doesn't wait for connection to close or buffer to fill up but returns immediately when it receives something. Sometimes it manages to read all my data and sometimes only the first stream. `TCPSocket#read` returns after connection is closed or buffer is full. Changing from `recv` to `read` fixed my issue.

I've added test that covers this case.
