### PR TITLE
Minor changes to the main loop for certain shutdown scenarios

### DIFF
--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -44,15 +44,17 @@ module FakeFtp
       @thread = Thread.new do
         while @started
           @client = @server.accept rescue nil
-          respond_with('220 Can has FTP?')
-          @connection = Thread.new(@client) do |socket|
-            while @started && !socket.nil? && !socket.closed?
-              input = socket.gets rescue nil
-              respond_with parse(input) if input
-            end
-            unless @client.nil?
-              @client.close unless @client.closed?
-              @client = nil
+          if @client
+            respond_with('220 Can has FTP?')
+            @connection = Thread.new(@client) do |socket|
+              while @started && !socket.nil? && !socket.closed?
+                input = socket.gets rescue nil
+                respond_with parse(input) if input
+              end
+              unless @client.nil?
+                @client.close unless @client.closed?
+                @client = nil
+              end
             end
           end
         end


### PR DESCRIPTION
When stopping a fake_ftp server I was experiencing problems where sockets were still be listened to after being closed, or methods were being called on objects which had been nilified.  These changes add extra guard conditions to prevent these problems.
