### PR TITLE
Add Support for Wildcard Arguments in LIST Command

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gemspec
 
 group :test do
   gem "guard-rspec"
-  gem "debugger"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,13 +6,6 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    columnize (0.3.6)
-    debugger (1.6.1)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.2.3)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.2.3)
     diff-lcs (1.1.3)
     ffi (1.0.11)
     guard (1.0.1)
@@ -35,7 +28,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  debugger
   fake_ftp!
   guard-rspec
   rake (>= 0.8.7)


### PR DESCRIPTION
This adds support for wildcards arguments in the LIST command. It supports single and multiple wildcard arguments. It does not alter behavior for no arguments.
