### PR TITLE
Add support for SITE command

### DIFF
--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -28,6 +28,7 @@ module FakeFtp
       rnto
       type
       user
+      site
     )
     LNBK = "\r\n"
 
@@ -312,6 +313,10 @@ module FakeFtp
 
     def _mkd(directory)
       "257 OK!"
+    end
+
+    def _site(command)
+      "200 #{command}"
     end
 
     def active?

--- a/spec/functional/server_spec.rb
+++ b/spec/functional/server_spec.rb
@@ -38,6 +38,12 @@ describe FakeFtp::Server, 'commands' do
       client.gets
       client.puts "USER thing"
     end
+
+    it "should accept SITE command" do
+      client.gets
+      client.puts "SITE umask"
+      expect(client.gets).to eql "200 umask\r\n"
+    end
   end
 
   context 'passive' do

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -71,6 +71,10 @@ describe FakeFtp::Server, 'with ftp client' do
       expect(server.file('text_file.txt')).to be_active
     end
 
+    it "should allow client to execute SITE command" do
+      expect { client.site('umask') }.to_not raise_error
+    end
+
     xit "should disconnect clients on close" do
       # TODO: when this succeeds, we can care less about manually closing clients
       #       otherwise we get a CLOSE_WAIT process hanging around that blocks our port


### PR DESCRIPTION
Ruby has `Net::FTP#site`, so I add `_site` method. 

Now fake_ftp raises `Net::FTPPermError` when client executes `Net::FTP#site`, but I think it should return status `200`.
