### PR TITLE
Drop testing of ruby 2.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,3 @@ cache: bundler
 rvm:
 - 2.4.1
 - 2.3.4
-- 2.2.7


### PR DESCRIPTION
since it is the most commonly-failing ruby version with TCPServer
flakiness, and it's near EOL anyway.