### PR TITLE
Enhance README for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,27 @@ FakeFtp is a simple FTP server that fakes out enough of the protocol to get us
 by, allowing us to test that files get to their intended destination rather than
 testing how our code does so.
 
+## Installation
+
+For Ruby version under 2.3.0
+
+```
+# Gemfile
+gem 'fake_ftp', ~> '0.2.0'
+
+# Gem install
+gem install fake_ftp -v 0.2.0
+```
+
+Ruby version is 2.3.0 or above
+
+```
+gem 'fake_ftp'
+
+# or
+gem install fake_ftp
+```
+
 ## Usage
 
 To test passive upload:


### PR DESCRIPTION
Since `0.3.0` is no longer support Ruby version under `2.3.0`, should
add a guide to tell people install previous version (which is `0.2.0`)

issue #52