### PR TITLE
Return correct paths when files are uploaded to different directories

### DIFF
--- a/lib/fake_ftp/file.rb
+++ b/lib/fake_ftp/file.rb
@@ -20,10 +20,6 @@ module FakeFtp
       @last_modified_time = last_modified_time.utc
     end
 
-    def basename
-      ::File.basename(@name)
-    end
-
     def data=(data)
       @data = data
       @bytes = @data.nil? ? nil : data.length

--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -35,20 +35,20 @@ module FakeFtp
     end
 
     def files
-      @store.values.map do |f|
+      @store.map do |full_path, file|
         if absolute?
-          abspath(f.name)
+          full_path
         else
-          f.name
+          file.name
         end
       end
     end
 
     def file(name)
-      @store.values.detect do |f|
-        if absolute?
-          abspath(f.name) == name
-        else
+      if absolute?
+        @store[name]
+      else
+        @store.values.detect do |f|
           f.name == name
         end
       end
@@ -62,6 +62,13 @@ module FakeFtp
       @store[abspath(filename)] = FakeFtp::File.new(
         filename.to_s, data, options[:mode], last_modified_time
       )
+    end
+
+    def rename_file(old_name, new_name)
+      file = @store.delete(abspath(old_name))
+      raise ArgumentError, "file not found #{old_name}" if file.nil?
+      file.name = ::File.basename(new_name)
+      @store[abspath(new_name)] = file
     end
 
     def start

--- a/lib/fake_ftp/server_commands/rnto.rb
+++ b/lib/fake_ftp/server_commands/rnto.rb
@@ -7,13 +7,13 @@ module FakeFtp
         return '501 Send path name.' if rename_to.nil? || rename_to.empty?
         return '503 Send RNFR first.' if ctx.command_state[:rename_from].nil?
 
-        f = ctx.file(ctx.command_state[:rename_from])
-        if f.nil?
+        begin
+          ctx.rename_file(ctx.command_state[:rename_from], rename_to)
+        rescue ArgumentError
           ctx.command_state[:rename_from] = nil
           return '550 File not found.'
         end
 
-        f.name = rename_to
         ctx.command_state[:rename_from] = nil
         '250 Path renamed.'
       end

--- a/spec/integration/server_spec.rb
+++ b/spec/integration/server_spec.rb
@@ -62,6 +62,19 @@ describe FakeFtp::Server, 'with ftp client', integration: true do
       expect(server.file('/pub/text_file.txt')).to_not be_active
     end
 
+    it "should put different files in different directories" do
+      expect(File.stat(text_filename).size).to eql(20)
+
+      client.passive = true
+      client.put(text_filename)
+
+      client.chdir("/tmp")
+      client.put(text_filename, "other_file.txt")
+
+      expect(server.files).to include('/pub/text_file.txt')
+      expect(server.files).to include('/tmp/other_file.txt')
+    end
+
     it 'should put files using active' do
       expect(File.stat(text_filename).size).to eql(20)
 

--- a/spec/models/fake_ftp/server_spec.rb
+++ b/spec/models/fake_ftp/server_spec.rb
@@ -74,4 +74,12 @@ describe FakeFtp::Server, 'files' do
     server.reset
     expect(server.files).to eql([])
   end
+
+  it 'can rename files' do
+    server.rename_file('filename', 'other')
+
+    expect(server.files).to include('other')
+    expect(server.files).to_not include('filename')
+    expect(server.file('other')).to eql(file)
+  end
 end


### PR DESCRIPTION
#42 added basic directory support that works fine as long as you only use a single directory.

But if you upload files to different directories, `FakeFtp::Server#files` would list all files as if they resided in the last directory used (aka PWD).

I hope the test case I added further illustrates the issue.

I tried two different approaches before finding this solution.

At first I tried just the changes to `FakeFtp::Server#files` that are now also in my final solution. But renaming files would not work then, because only the `name` of the `File` object was changed, not the file's key in the server's `@store`.

Then I saw `FakeFtp::File#basename` and thought there might have been a misunderstanding and the `name` of the `FakeFtp::File` should have been a full path. But I quickly found out that this was never the case. `FakeFtp::File` objects are always instantiated with a normalized "basename". And this is assumed in so many places that trying to change that seemed too complicated.

So I opted to improve renaming of files. I hope my solution is not too far off. I would love feedback either way.

I also removed `FakeFtp::File#basename` as it had me confused, did in practice never return anything different than `#name` and was not called anywhere.