### PR TITLE
Fix Pathname compatibility.

### DIFF
--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -154,7 +154,7 @@ module FakeFtp
     private :options
 
     def abspath(filename)
-      return filename if filename.start_with?('/')
+      return filename if filename.to_s.start_with?('/')
       [@workdir.to_s, filename].join('/').gsub('//', '/')
     end
 


### PR DESCRIPTION
Until PR #42 was merged, String, as well as Pathname objects, were supported just fine. Now, just String is supported, because Pathname object does not support #start_with? method.

Therefore, this just naively converts everything to String to fix Pathname support. I can imagine, that it would use Pathname#absolute? if available, but not sure what would be the result.

Please note that this fixes "4) Vagrant::Action::Builtin::BoxAdd with box file directly adds from FTP URL    Failure/Error: server.add_file(path.basename, path.read)" failure mentioned in hashicorp/vagrant/issues/10646