### PR TITLE
Support file paths with spaces for RETR command

### DIFF
--- a/lib/fake_ftp/server_commands/retr.rb
+++ b/lib/fake_ftp/server_commands/retr.rb
@@ -3,7 +3,8 @@
 module FakeFtp
   module ServerCommands
     class Retr
-      def run(ctx, filename = '', *)
+      def run(ctx, *filename_parts)
+        filename = filename_parts.join(' ')
         ctx.respond_with('501 No filename given') if filename.empty?
 
         f = ctx.file(filename.to_s)

--- a/spec/functional/server_spec.rb
+++ b/spec/functional/server_spec.rb
@@ -298,6 +298,18 @@ describe FakeFtp::Server, 'commands', functional: true do
             .to eql("226 File transferred\r\n")
         end
 
+        it 'accepts RETR with a filepath containing spaces' do
+          server.add_file(file_prefix + 'some dir/some file', '1234567890')
+          client.write("RETR #{file_prefix}some dir/some file\r\n")
+          expect(SpecHelper.gets_with_timeout(client))
+            .to eql("150 File status ok, about to open data connection\r\n")
+          data = SpecHelper.gets_with_timeout(data_client, endwith: "\0")
+          data_client.close
+          expect(data).to eql('1234567890')
+          expect(SpecHelper.gets_with_timeout(client))
+            .to eql("226 File transferred\r\n")
+        end
+
         it 'accepts DELE with a filename' do
           server.add_file('some_file', '1234567890')
           client.write("DELE some_file\r\n")


### PR DESCRIPTION
Because the FTP command is splitted by spaces, file paths with spaces
are not supported, because the Retr command only uses the first part of
the path until the first space. This change ensures all parts are used.

This change fixed a specific problem for me, but I did not test other commands. However, looking at some FTP documentation, it seems that commands that accept more than one parameter are an exception, so I could imagine a command should just receive of string of all characters except the command name itself. That would solve the problem for all commands IMO.