### PR TITLE
Close socket when client sends EOF

### DIFF
--- a/lib/fake_ftp/server.rb
+++ b/lib/fake_ftp/server.rb
@@ -83,6 +83,7 @@ module FakeFtp
             debug('enter request thread')
             while @started && !socket.nil? && !socket.closed?
               input = begin
+                        socket.close and break if socket.eof?
                         socket.gets
                       rescue
                         debug("error on socket.gets: #{e}")


### PR DESCRIPTION
As is:
When a client triggers EOF in server to close connection (in Ruby's client `ftp.close`) the server doesn't handle this signal and forces the client to wait on read. 

To be:
When EOF is received, close the socket immediately.

How to reproduce:
```ruby
FakeFtp::Server.new(21212)
server.start

ftp_client = Net::FTP.new
ftp_client.connect('127.0.0.1', 21212)
ftp_client.login('user', 'password')
Benchmark.measure{ ftp_client.close }
=> #<Benchmark::Tms:0x00007fecfad73068
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=3.003513000003295,
 @stime=0.15119499999999997,
 @total=3.000451,
 @utime=2.849256>

...
```
Another run on this branch:
```ruby
FakeFtp::Server.new(21212)
server.start

ftp_client = Net::FTP.new
ftp_client.connect('127.0.0.1', 21212)
ftp_client.login('user', 'password')
Benchmark.measure{ ftp_client.close }
=> #<Benchmark::Tms:0x00007fefe91c6688
 @cstime=0.0,
 @cutime=0.0,
 @label="",
 @real=0.0002390000008745119,
 @stime=8.900000000000574e-05,
 @total=0.0002629999999999022,
 @utime=0.00017399999999989646>
```

This is where the 3s of wait comes from https://github.com/ruby/ruby/blob/ruby_2_6/lib/net/ftp.rb#L1308

Furthermore, I suspect that this is the reason why _integration_ and _functional_ tests are [disabled](https://github.com/livinginthepast/fake_ftp/blob/master/spec/spec_helper.rb#L11-L12) by default in this project. With this fix, the execution time shrinks significantly - from `Finished in 21.24 seconds (files took 0.14215 seconds to load)` to `Finished in 0.21783 seconds (files took 0.14647 seconds to load)`